### PR TITLE
Fixed the logo being squished with long text

### DIFF
--- a/quid-payments/css/init.css
+++ b/quid-payments/css/init.css
@@ -28,7 +28,8 @@
 
 .quid-slider-wrapper.quid-slider-default {
     margin: 0px 0px 0px auto;
-    width: 175px;
+    width: auto;
+    display: inline-block;
 }
 
 .quid-pay-already-paid .quid-pay-button {


### PR DESCRIPTION
The slider is no bigger than the width of the buttons.

<img width="573" alt="Screen Shot 2019-05-10 at 3 24 21 PM" src="https://user-images.githubusercontent.com/17042685/57551700-b34bde00-7337-11e9-8bec-21f61cbf45fa.png">